### PR TITLE
Uses correct filename (hooks/pre-build) in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Hooks :
 
 ## Example
 
-Add a script `hooks/pre_build` in a dokku project.
+Add a script `hooks/pre-build` in a dokku project.
 ```bash
 #!/usr/bin/env bash
 


### PR DESCRIPTION
@fteychene Hi there!

I noticed my build hook wasn't executing with a file named `hooks/pre_build`. I looked into the source and saw it was expecting a file called `hooks/pre-build`.

This just updates the README so other people won't accidentally make the same mistake.